### PR TITLE
Add _microseconds suffix as per prometheus requirements

### DIFF
--- a/src/collectors/vm/prometheus_vm_msacc_collector.erl
+++ b/src/collectors/vm/prometheus_vm_msacc_collector.erl
@@ -14,86 +14,86 @@
 %%
 %% <ul>
 %%   <li>
-%%     `erlang_vm_msacc_aux'<br/>
+%%     `erlang_vm_msacc_aux_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent handling auxiliary jobs.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_check_io'<br/>
+%%     `erlang_vm_msacc_check_io_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent checking for new I/O events.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_emulator'<br/>
+%%     `erlang_vm_msacc_emulator_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent executing Erlang processes.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_gc'<br/>
+%%     `erlang_vm_msacc_gc_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent doing garbage collection.
 %%     When extra states are enabled this is the time spent
 %%     doing non-fullsweep garbage collections.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_other'<br/>
+%%     `erlang_vm_msacc_other_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent doing unaccounted things.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_port'<br/>
+%%     `erlang_vm_msacc_port_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent executing ports.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_sleep'<br/>
+%%     `erlang_vm_msacc_sleep_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent sleeping.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_alloc'<br/>
+%%     `erlang_vm_msacc_alloc_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent managing memory.
 %%     Without extra states this time is spread out over all other states.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_bif'<br/>
+%%     `erlang_vm_msacc_bif_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent in BIFs.
 %%     Without extra states this time is part of the 'emulator' state.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_busy_wait'<br/>
+%%     `erlang_vm_msacc_busy_wait_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent busy waiting.
 %%     Without extra states this time is part of the 'other' state.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_ets'<br/>
+%%     `erlang_vm_msacc_ets_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent executing ETS BIFs.
 %%     Without extra states this time is part of the 'emulator' state.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_gc_full'<br/>
+%%     `erlang_vm_msacc_gc_full_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent doing fullsweep garbage collection.
 %%     Without extra states this time is part of the 'gc' state.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_nif'<br/>
+%%     `erlang_vm_msacc_nif_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent in NIFs.
 %%     Without extra states this time is part of the 'emulator' state.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_send'<br/>
+%%     `erlang_vm_msacc_send_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent sending messages (processes only).
 %%     Without extra states this time is part of the 'emulator' state.
 %%   </li>
 %%   <li>
-%%     `erlang_vm_msacc_timers'<br/>
+%%     `erlang_vm_msacc_timers_microseconds'<br/>
 %%     Type: counter.<br/>
 %%     Time in microseconds spent managing timers.
 %%     Without extra states this time is part of the 'other' state.
@@ -111,49 +111,49 @@
 %% </a>:
 %% <ul>
 %%   <li>
-%%     `aux' for `erlang_vm_msacc_aux'.
+%%     `aux' for `erlang_vm_msacc_aux_microseconds'.
 %%   </li>
 %%   <li>
-%%     `check_io' for `erlang_vm_msacc_check_io'.
+%%     `check_io' for `erlang_vm_msacc_check_io_microseconds'.
 %%   </li>
 %%   <li>
-%%     `emulator' for `erlang_vm_msacc_emulator'.
+%%     `emulator' for `erlang_vm_msacc_emulator_microseconds'.
 %%   </li>
 %%   <li>
-%%     `gc' for `erlang_vm_msacc_gc'.
+%%     `gc' for `erlang_vm_msacc_gc_microseconds'.
 %%   </li>
 %%   <li>
-%%     `other' for `erlang_vm_msacc_other'.
+%%     `other' for `erlang_vm_msacc_other_microseconds'.
 %%   </li>
 %%   <li>
-%%     `port' for `erlang_vm_msacc_port'.
+%%     `port' for `erlang_vm_msacc_port_microseconds'.
 %%   </li>
 %%   <li>
-%%     `sleep' for `erlang_vm_msacc_sleep'.
+%%     `sleep' for `erlang_vm_msacc_sleep_microseconds'.
 %%   </li>
 %%   <li>
-%%     `alloc' for `erlang_vm_msacc_alloc'.
+%%     `alloc' for `erlang_vm_msacc_alloc_microseconds'.
 %%   </li>
 %%   <li>
-%%     `bif' for `erlang_vm_msacc_bif'.
+%%     `bif' for `erlang_vm_msacc_bif_microseconds'.
 %%   </li>
 %%   <li>
-%%     `busy_wait' for `erlang_vm_msacc_busy_wait'.
+%%     `busy_wait' for `erlang_vm_msacc_busy_wait_microseconds'.
 %%   </li>
 %%   <li>
-%%     `ets' for `erlang_vm_msacc_ets'.
+%%     `ets' for `erlang_vm_msacc_ets_microseconds'.
 %%   </li>
 %%   <li>
-%%     `gc_full' for `erlang_vm_msacc_gc_full'.
+%%     `gc_full' for `erlang_vm_msacc_gc_full_microseconds'.
 %%   </li>
 %%   <li>
-%%     `nif' for `erlang_vm_msacc_nif'.
+%%     `nif' for `erlang_vm_msacc_nif_microseconds'.
 %%   </li>
 %%   <li>
-%%     `send' for `erlang_vm_msacc_send'.
+%%     `send' for `erlang_vm_msacc_send_microseconds'.
 %%   </li>
 %%   <li>
-%%     `timers' for `erlang_vm_msacc_timers'.
+%%     `timers' for `erlang_vm_msacc_timers_microseconds'.
 %%   </li>
 %% </ul>
 %%
@@ -206,59 +206,59 @@ metrics() ->
   Data = erlang:statistics(microstate_accounting),
   [
    %% Base states.
-   {aux, counter,
+   {aux_microseconds, counter,
     "Time in microseconds spent handling auxiliary jobs.",
     metric(aux, Data)},
-   {check_io, counter,
+   {check_io_microseconds, counter,
     "Time in microseconds spent checking for new I/O events.",
     metric(check_io, Data)},
-   {emulator, counter,
+   {emulator_microseconds, counter,
     "Time in microseconds spent executing Erlang processes.",
     metric(emulator, Data)},
-   {gc, counter,
+   {gc_microseconds, counter,
     "Time in microseconds spent doing garbage collection. "
     "When extra states are enabled this is the time spent "
     "doing non-fullsweep garbage collections.",
     metric(gc, Data)},
-   {other, counter,
+   {other_microseconds, counter,
     "Time in microseconds spent doing unaccounted things.",
     metric(other, Data)},
-   {port, counter,
+   {port_microseconds, counter,
     "Time in microseconds spent executing ports.",
     metric(port, Data)},
-   {sleep, counter,
+   {sleep_microseconds, counter,
     "Time in microseconds spent sleeping.",
     metric(sleep, Data)},
    %% Extra states.
-   {alloc, counter,
+   {alloc_microseconds, counter,
     "Time in microseconds spent managing memory. "
     "Without extra states this time is spread out over all other states.",
     metric(alloc, Data)},
-   {bif, counter,
+   {bif_microseconds, counter,
     "Time in microseconds spent in BIFs. "
     "Without extra states this time is part of the 'emulator' state.",
     metric(bif, Data)},
-   {busy_wait, counter,
+   {busy_wait_microseconds, counter,
     "Time in microseconds spent busy waiting. "
     "Without extra states this time is part of the 'other' state.",
     metric(busy_wait, Data)},
-   {ets, counter,
+   {ets_microseconds, counter,
     "Time in microseconds spent executing ETS BIFs. "
     "Without extra states this time is part of the 'emulator' state.",
     metric(ets, Data)},
-   {gc_full, counter,
+   {gc_full_microseconds, counter,
     "Time in microseconds spent doing fullsweep garbage collection. "
     "Without extra states this time is part of the 'gc' state.",
     metric(gc_full, Data)},
-   {nif, counter,
+   {nif_microseconds, counter,
     "Time in microseconds spent in NIFs. "
     "Without extra states this time is part of the 'emulator' state.",
     metric(nif, Data)},
-   {send, counter,
+   {send_microseconds, counter,
     "Time in microseconds spent sending messages (processes only). "
     "Without extra states this time is part of the 'emulator' state.",
     metric(send, Data)},
-   {timers, counter,
+   {timers_microseconds, counter,
     "Time in microseconds spent managing timers. "
     "Without extra states this time is part of the 'other' state.",
     metric(timers, Data)}

--- a/test/eunit/collectors/vm/prometheus_vm_msacc_collector_tests.erl
+++ b/test/eunit/collectors/vm/prometheus_vm_msacc_collector_tests.erl
@@ -16,22 +16,22 @@ test_default_metrics(_) ->
   Metrics = prometheus_text_format:format(),
   [
    %% Base.
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_check_io")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_emulator")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_other")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_port")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_sleep")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_check_io_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_emulator_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_other_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_port_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_sleep_microseconds")),
    %% Extra.
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_alloc")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_bif")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_busy_wait")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_ets")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_full")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_nif")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_send")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_timers"))
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_alloc_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_bif_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_busy_wait_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_ets_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_full_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_nif_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_send_microseconds")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_timers_microseconds"))
   ].
 
 
@@ -40,43 +40,43 @@ test_all_metrics(_) ->
     application:set_env(prometheus, vm_msacc_collector_metrics,
                         [
                          %% Base.
-                         aux,
-                         check_io,
-                         emulator,
-                         gc,
-                         other,
-                         port,
-                         sleep,
+                         aux_microseconds,
+                         check_io_microseconds,
+                         emulator_microseconds,
+                         gc_microseconds,
+                         other_microseconds,
+                         port_microseconds,
+                         sleep_microseconds,
                          %% Extra.
-                         alloc,
-                         bif,
-                         busy_wait,
-                         ets,
-                         gc_full,
-                         nif,
-                         send,
-                         timers
+                         alloc_microseconds,
+                         bif_microseconds,
+                         busy_wait_microseconds,
+                         ets_microseconds,
+                         gc_full_microseconds,
+                         nif_microseconds,
+                         send_microseconds,
+                         timers_microseconds
                         ]),
     prometheus_registry:register_collector(prometheus_vm_msacc_collector),
     Metrics = prometheus_text_format:format(),
     [
      %% Base.
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_check_io")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_emulator")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_other")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_port")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_sleep")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_check_io_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_emulator_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_other_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_port_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_sleep_microseconds")),
      %% Extra.
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_alloc")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_bif")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_busy_wait")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_ets")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_full")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_nif")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_send")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_timers"))
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_alloc_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_bif_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_busy_wait_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_ets_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_full_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_nif_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_send_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_timers_microseconds"))
     ]
 
   after
@@ -88,32 +88,32 @@ test_custom_metrics(_) ->
   try
     application:set_env(prometheus, vm_msacc_collector_metrics,
                         [
-                         aux,
-                         emulator,
-                         gc,
-                         gc_full,
-                         nif
+                         aux_microseconds,
+                         emulator_microseconds,
+                         gc_microseconds,
+                         gc_full_microseconds,
+                         nif_microseconds
                         ]),
     prometheus_registry:register_collector(prometheus_vm_msacc_collector),
     Metrics = prometheus_text_format:format(),
     [
      %% Base.
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_check_io")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_emulator")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_other")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_port")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_sleep")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_check_io_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_emulator_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_other_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_port_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_sleep_microseconds")),
      %% Extra.
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_alloc")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_bif")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_busy_wait")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_ets")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_full")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_nif")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_send")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_timers"))
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_alloc_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_bif_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_busy_wait_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_ets_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_gc_full_microseconds")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_nif_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_send_microseconds")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_msacc_timers_microseconds"))
     ]
 
   after
@@ -131,5 +131,5 @@ test_global_labels(_) ->
     application:unset_env(prometheus, global_labels)
   end,
   [
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux{node="))
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_msacc_aux_microseconds{node="))
   ].


### PR DESCRIPTION
https://prometheus.io/docs/practices/naming/#metric-and-label-naming

In response to the discussion in deadtrickster/prometheus.erl#98

These statistics are a "special case" as noted by @essen in the discussion. Using seconds as suggested by prometheus would lose the sort of resolution these statistics require.